### PR TITLE
Add information about keys and presence into `GetConditionalValues` 

### DIFF
--- a/escrow/atomic_storage.go
+++ b/escrow/atomic_storage.go
@@ -31,11 +31,11 @@ type AtomicStorage interface {
 }
 
 type Transaction interface {
-	GetConditionValues() []string
+	GetConditionValues() ([]*KeyValueData, error)
 }
 
 //Best to change this to KeyValueData , will do this in the next commit
-type UpdateFunc func(conditionValues []string) (update []*KeyValueData, err error)
+type UpdateFunc func(conditionValues []*KeyValueData) (update []*KeyValueData, err error)
 
 type CASRequest struct {
 	RetryTillSuccessOrError bool
@@ -44,8 +44,9 @@ type CASRequest struct {
 }
 
 type KeyValueData struct {
-	Key   string
-	Value string
+	Key     string
+	Value   string
+	Present bool
 }
 
 // PrefixedAtomicStorage is decorator for atomic storage which adds a prefix to
@@ -126,11 +127,11 @@ type TypedAtomicStorage interface {
 }
 
 type TypedTransaction interface {
-	GetConditionValues() []interface{}
+	GetConditionValues() ([]*TypedKeyValueData, error)
 }
 
 //Best to change this to KeyValueData , will do this in the next commit
-type TypedUpdateFunc func(conditionValues []interface{}) (update []*TypedKeyValueData, err error)
+type TypedUpdateFunc func(conditionValues []*TypedKeyValueData) (update []*TypedKeyValueData, err error)
 
 type TypedCASRequest struct {
 	RetryTillSuccessOrError bool
@@ -139,8 +140,9 @@ type TypedCASRequest struct {
 }
 
 type TypedKeyValueData struct {
-	Key   interface{}
-	Value interface{}
+	Key     interface{}
+	Value   interface{}
+	Present bool
 }
 
 // TypedAtomicStorageImpl is an implementation of TypedAtomicStorage interface
@@ -169,13 +171,30 @@ func (storage *TypedAtomicStorageImpl) Get(key interface{}) (value interface{}, 
 		return
 	}
 
-	value = reflect.New(storage.valueType).Interface()
-	err = storage.valueDeserializer(valueString, value)
+	value, err = storage.deserializeValue(valueString)
 	if err != nil {
 		return nil, false, err
 	}
 
 	return value, true, nil
+}
+
+func (storage *TypedAtomicStorageImpl) deserializeKey(keyString string) (key interface{}, err error) {
+	key = reflect.New(storage.keyType).Interface()
+	err = storage.keyDeserializer(keyString, key)
+	if err != nil {
+		return nil, err
+	}
+	return key, err
+}
+
+func (storage *TypedAtomicStorageImpl) deserializeValue(valueString string) (value interface{}, err error) {
+	value = reflect.New(storage.valueType).Interface()
+	err = storage.valueDeserializer(valueString, value)
+	if err != nil {
+		return nil, err
+	}
+	return value, err
 }
 
 func (storage *TypedAtomicStorageImpl) GetAll() (array interface{}, err error) {
@@ -264,34 +283,47 @@ type typedTransactionImpl struct {
 	storage           *TypedAtomicStorageImpl
 }
 
-func (transaction *typedTransactionImpl) GetConditionValues() []interface{} {
-	resultString := transaction.transactionString.GetConditionValues()
-	result := make([]interface{}, len(resultString))
-	for i, valueString := range resultString {
-		result[i] = reflect.New(transaction.storage.valueType)
-		transaction.storage.valueDeserializer(valueString, result[i])
+func (transaction *typedTransactionImpl) GetConditionValues() ([]*TypedKeyValueData, error) {
+	keyValueDataString, err := transaction.transactionString.GetConditionValues()
+	if err != nil {
+		return nil, err
 	}
-	return result
+	return transaction.storage.convertKeyValueDataToTyped(keyValueDataString)
 }
 
-func (storage *TypedAtomicStorageImpl) GetConditionTypedValues(conditionKeyValues []string) []interface{} {
-	result := make([]interface{}, len(conditionKeyValues))
-	for i, valueString := range conditionKeyValues {
-		result[i] = reflect.New(storage.valueType)
-		storage.valueDeserializer(valueString, result[i])
+func (storage *TypedAtomicStorageImpl) convertKeyValueDataToTyped(keyValueData []*KeyValueData) ([]*TypedKeyValueData, error) {
+	result := make([]*TypedKeyValueData, len(keyValueData))
+	for i, keyValueString := range keyValueData {
+		// TODO: how to process err here?
+		key, err := storage.deserializeKey(keyValueString.Key)
+		if err != nil {
+			return nil, err
+		}
+		value, err := storage.deserializeValue(keyValueString.Value)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = &TypedKeyValueData{
+			Key:     key,
+			Value:   value,
+			Present: keyValueString.Present,
+		}
 	}
-	return result
+	return result, nil
 }
 
 func (storage *TypedAtomicStorageImpl) ExecuteTransaction(request TypedCASRequest) (ok bool, err error) {
 
-	updateFunction := func(conditionValues []string) (update []*KeyValueData, err error) {
-		typedValues := storage.GetConditionTypedValues(conditionValues)
+	updateFunction := func(conditionValues []*KeyValueData) (update []*KeyValueData, err error) {
+		typedValues, err := storage.convertKeyValueDataToTyped(conditionValues)
+		if err != nil {
+			return nil, err
+		}
 		typedUpdate, err := request.Update(typedValues)
 		if err != nil {
 			return nil, err
 		}
-		return storage.ConvertToKeyValueData(typedUpdate)
+		return storage.convertTypedKeyValueDataToString(typedUpdate)
 	}
 
 	storageRequest := CASRequest{
@@ -314,7 +346,7 @@ func (storage *TypedAtomicStorageImpl) StartTransaction(keyPrefix string) (trans
 	}, nil
 }
 
-func (storage *TypedAtomicStorageImpl) ConvertToKeyValueData(
+func (storage *TypedAtomicStorageImpl) convertTypedKeyValueDataToString(
 	update []*TypedKeyValueData) (data []*KeyValueData, err error) {
 	updateString := make([]*KeyValueData, len(update))
 	for i, keyValue := range update {
@@ -334,7 +366,7 @@ func (storage *TypedAtomicStorageImpl) ConvertToKeyValueData(
 	return updateString, nil
 }
 func (storage *TypedAtomicStorageImpl) CompleteTransaction(transaction TypedTransaction, update []*TypedKeyValueData) (ok bool, err error) {
-	updateString, err := storage.ConvertToKeyValueData(update)
+	updateString, err := storage.convertTypedKeyValueDataToString(update)
 	if err != nil {
 		return false, err
 	}

--- a/escrow/atomic_storage.go
+++ b/escrow/atomic_storage.go
@@ -147,6 +147,8 @@ type TypedKeyValueData struct {
 type TypedAtomicStorageImpl struct {
 	atomicStorage     AtomicStorage
 	keySerializer     func(key interface{}) (serialized string, err error)
+	keyDeserializer   func(serialized string, key interface{}) (err error)
+	keyType           reflect.Type
 	valueSerializer   func(value interface{}) (serialized string, err error)
 	valueDeserializer func(serialized string, value interface{}) (err error)
 	valueType         reflect.Type

--- a/escrow/free_call_storage.go
+++ b/escrow/free_call_storage.go
@@ -16,6 +16,8 @@ func NewFreeCallUserStorage(atomicStorage AtomicStorage) *FreeCallUserStorage {
 				keyPrefix: "/free-call-user/storage",
 			},
 			keySerializer:     serialize,
+			keyDeserializer:   deserialize,
+			keyType:           reflect.TypeOf(FreeCallUserKey{}),
 			valueSerializer:   serialize,
 			valueDeserializer: deserialize,
 			valueType:         reflect.TypeOf(FreeCallUserData{}),

--- a/escrow/payment_channel_storage.go
+++ b/escrow/payment_channel_storage.go
@@ -26,6 +26,8 @@ func NewPaymentChannelStorage(atomicStorage AtomicStorage) *PaymentChannelStorag
 		delegate: &TypedAtomicStorageImpl{
 			atomicStorage:     NewPrefixedAtomicStorage(atomicStorage, "/payment-channel/storage"),
 			keySerializer:     serialize,
+			keyDeserializer:   deserialize,
+			keyType:           reflect.TypeOf(PaymentChannelKey{}),
 			valueSerializer:   serialize,
 			valueDeserializer: deserialize,
 			valueType:         reflect.TypeOf(PaymentChannelData{}),

--- a/escrow/payment_storage.go
+++ b/escrow/payment_storage.go
@@ -18,6 +18,8 @@ func NewPaymentStorage(atomicStorage AtomicStorage) *PaymentStorage {
 
 			atomicStorage:     NewPrefixedAtomicStorage(atomicStorage, "/payment/storage"),
 			keySerializer:     serialize,
+			keyDeserializer:   deserialize,
+			keyType:           reflect.TypeOf(""),
 			valueSerializer:   serialize,
 			valueDeserializer: deserialize,
 			valueType:         reflect.TypeOf(Payment{}),

--- a/escrow/prepaid_service.go
+++ b/escrow/prepaid_service.go
@@ -49,10 +49,16 @@ func (h *lockingPrepaidService) UpdateUsage(channelId *big.Int, revisedAmount *b
 		return fmt.Errorf("Unknow Update type %v", updateUsageType)
 	}
 
-	typedUpdateFunc := func(conditionValues []interface{}) (update []*TypedKeyValueData, err error) {
+	typedUpdateFunc := func(conditionValues []*TypedKeyValueData) (update []*TypedKeyValueData, err error) {
+		var oldValues []interface{}
 		var newValues interface{}
 
-		if newValues, err = conditionFunc(conditionValues, revisedAmount); err != nil {
+		oldValues = make([]interface{}, len(conditionValues))
+		for i, keyValue := range conditionValues {
+			oldValues[i] = keyValue.Value
+		}
+
+		if newValues, err = conditionFunc(oldValues, revisedAmount); err != nil {
 			return nil, err
 		}
 

--- a/escrow/prepaid_storage.go
+++ b/escrow/prepaid_storage.go
@@ -89,6 +89,8 @@ func NewPrepaidStorage(atomicStorage AtomicStorage) TypedAtomicStorage {
 	return &TypedAtomicStorageImpl{
 		atomicStorage:     NewPrefixedAtomicStorage(atomicStorage, "/PrePaid/storage"),
 		keySerializer:     serialize,
+		keyDeserializer:   deserialize,
+		keyType:           reflect.TypeOf(""),
 		valueSerializer:   serialize,
 		valueDeserializer: deserialize,
 		valueType:         reflect.TypeOf(PrePaidDataUnit{}),


### PR DESCRIPTION
Add information about keys into `GetConditionalValues` method to allow client matching returned values by key.
Add information key presence in order to implement `PutIfAbsent` correctly.
Fixing `PutIfAbsent` to pass unit test.